### PR TITLE
workaround for dimension problem causing visibility issues in 0.4.11

### DIFF
--- a/napari_ome_zarr/_reader.py
+++ b/napari_ome_zarr/_reader.py
@@ -101,6 +101,17 @@ def transform(nodes: Iterator[Node]) -> Optional[ReaderFunction]:
                     for x in METADATA_KEYS:
                         if x in node.metadata:
                             metadata[x] = node.metadata[x]
+                    if len(shape) == 5: # dirty fix for issue with napari 0.4.11
+                        # a channel axis doesn't make sense in a label image
+                        # therefore it isn't extracted into separate layers.
+                        # This results in a dimensionality mismatch between image and labels
+                        # layers, which propagates through viewer.dims.points through
+                        # to layer.corner_pixels.
+                        channel_axis = 1
+                        dim_mask = [True] * 6
+                        dim_mask[channel_axis] = False
+                        metadata["affine"] = metadata["affine"][dim_mask, :][:, dim_mask]
+                        data=[d[:,0,...] for d in data]
                 else:
                     channel_axis = None
                     if "axes" in node.metadata:


### PR DESCRIPTION
Hi Andreas,

the following change is a workaround that helps avoid the problem with napari 0.4.11 encountered with the ngff-writer mini test set.

The workaround is bit quick and  dirty. It seems that  in napari, label images cannot be provided as 5D arrays with a singleton channel dimension without causing problems with viewer dimensions. The viewer dimensions get bumped to 5D, whereas for 5D image layers the viewer dimensions only get bumped to 4D, as the channel dimensional is sliced out into separate 4D layers.
Ultimately this results in incorrect calculation of `layer.corner_pixels`.

Edit: 
I documented the underlying problem in napari by adding to this existing issue: https://github.com/napari/napari/issues/2487